### PR TITLE
[03-01] Integrate ts-fsrs into packages/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,5 +19,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@10.28.2",
+  "dependencies": {
+    "ts-fsrs": "^5.3.1"
+  }
 }

--- a/packages/core/src/fsrs.test.ts
+++ b/packages/core/src/fsrs.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { scheduleCard, getDueCards, type FSRSCard } from "./fsrs";
+import { Rating } from "./rating";
+
+function newCard(overrides: Partial<FSRSCard> = {}): FSRSCard {
+  return {
+    stability: 0,
+    difficulty: 0,
+    dueDate: new Date().toISOString(),
+    lastReview: null,
+    reps: 0,
+    lapses: 0,
+    state: "NEW",
+    ...overrides,
+  };
+}
+
+const NOW = new Date("2024-01-01T12:00:00Z");
+
+// ─── scheduleCard — NEW card, all 4 ratings ───────────────────────────────────
+
+describe("scheduleCard — NEW card", () => {
+  it("Again: stays in LEARNING, dueDate is in the near future", () => {
+    const { card } = scheduleCard(newCard(), Rating.Again, NOW);
+    expect(card.state).toBe("LEARNING");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Hard: transitions to LEARNING", () => {
+    const { card } = scheduleCard(newCard(), Rating.Hard, NOW);
+    expect(card.state).toBe("LEARNING");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Good: transitions to LEARNING", () => {
+    const { card } = scheduleCard(newCard(), Rating.Good, NOW);
+    expect(card.state).toBe("LEARNING");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Easy: graduates directly to REVIEW", () => {
+    const { card } = scheduleCard(newCard(), Rating.Easy, NOW);
+    expect(card.state).toBe("REVIEW");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Good: reps increments", () => {
+    const { card } = scheduleCard(newCard(), Rating.Good, NOW);
+    expect(card.reps).toBeGreaterThan(0);
+  });
+});
+
+// ─── scheduleCard — REVIEW card, all 4 ratings ───────────────────────────────
+
+function reviewCard(): FSRSCard {
+  return newCard({
+    state: "REVIEW",
+    stability: 10,
+    difficulty: 5,
+    reps: 3,
+    lapses: 0,
+    lastReview: new Date("2023-12-22T12:00:00Z").toISOString(),
+    dueDate: NOW.toISOString(),
+  });
+}
+
+describe("scheduleCard — REVIEW card", () => {
+  it("Again: lapses increments, state becomes RELEARNING", () => {
+    const { card } = scheduleCard(reviewCard(), Rating.Again, NOW);
+    expect(card.lapses).toBeGreaterThan(0);
+    expect(card.state).toBe("RELEARNING");
+  });
+
+  it("Hard: stays in REVIEW, dueDate is in the future", () => {
+    const { card } = scheduleCard(reviewCard(), Rating.Hard, NOW);
+    expect(card.state).toBe("REVIEW");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Good: stays in REVIEW, dueDate is in the future", () => {
+    const { card } = scheduleCard(reviewCard(), Rating.Good, NOW);
+    expect(card.state).toBe("REVIEW");
+    expect(new Date(card.dueDate) > NOW).toBe(true);
+  });
+
+  it("Easy: stays in REVIEW, dueDate further out than Good", () => {
+    const { card: goodCard } = scheduleCard(reviewCard(), Rating.Good, NOW);
+    const { card: easyCard } = scheduleCard(reviewCard(), Rating.Easy, NOW);
+    expect(new Date(easyCard.dueDate) > new Date(goodCard.dueDate)).toBe(true);
+  });
+});
+
+// ─── scheduleCard — ReviewLog ─────────────────────────────────────────────────
+
+describe("scheduleCard — ReviewLog", () => {
+  it("log.reviewAt matches the supplied now", () => {
+    const { log } = scheduleCard(newCard(), Rating.Good, NOW);
+    expect(log.reviewAt).toBe(NOW.toISOString());
+  });
+
+  it("log.rating matches the supplied rating", () => {
+    const { log } = scheduleCard(newCard(), Rating.Hard, NOW);
+    expect(log.rating).toBe(Rating.Hard);
+  });
+
+  it("log.scheduledDays >= 0", () => {
+    const { log } = scheduleCard(newCard(), Rating.Good, NOW);
+    expect(log.scheduledDays).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─── getDueCards ──────────────────────────────────────────────────────────────
+
+describe("getDueCards", () => {
+  const past = new Date("2023-12-01T00:00:00Z").toISOString();
+  const future = new Date("2025-01-01T00:00:00Z").toISOString();
+
+  const cards: FSRSCard[] = [
+    newCard({ dueDate: past }),
+    newCard({ dueDate: NOW.toISOString() }), // exactly now — due
+    newCard({ dueDate: future }),
+  ];
+
+  it("returns cards with dueDate <= now", () => {
+    const due = getDueCards(cards, NOW);
+    expect(due).toHaveLength(2);
+  });
+
+  it("excludes cards with dueDate in the future", () => {
+    const due = getDueCards(cards, NOW);
+    due.forEach((c) => expect(new Date(c.dueDate) <= NOW).toBe(true));
+  });
+
+  it("returns empty array when no cards are due", () => {
+    const due = getDueCards([newCard({ dueDate: future })], NOW);
+    expect(due).toHaveLength(0);
+  });
+
+  it("preserves extra fields on subtype", () => {
+    type ExtCard = FSRSCard & { id: string };
+    const extCards: ExtCard[] = [{ ...newCard({ dueDate: past }), id: "abc" }];
+    const due = getDueCards(extCards, NOW);
+    expect(due[0].id).toBe("abc");
+  });
+});

--- a/packages/core/src/fsrs.ts
+++ b/packages/core/src/fsrs.ts
@@ -1,0 +1,116 @@
+import {
+  fsrs,
+  generatorParameters,
+  createEmptyCard,
+  Rating as FSRSRating,
+  State,
+  type Card as TSCard,
+  type RecordLogItem,
+} from "ts-fsrs";
+import type { Rating } from "./rating";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type CardState = "NEW" | "LEARNING" | "REVIEW" | "RELEARNING";
+
+export interface FSRSCard {
+  stability: number;
+  difficulty: number;
+  dueDate: string; // ISO 8601
+  lastReview: string | null;
+  reps: number;
+  lapses: number;
+  state: CardState;
+}
+
+export interface ReviewLog {
+  rating: Rating;
+  elapsedDays: number;
+  scheduledDays: number;
+  reviewAt: string; // ISO 8601
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+const scheduler = fsrs(generatorParameters({ request_retention: 0.9 }));
+
+const STATE_MAP: Record<CardState, State> = {
+  NEW: State.New,
+  LEARNING: State.Learning,
+  REVIEW: State.Review,
+  RELEARNING: State.Relearning,
+};
+
+const STATE_REVERSE: Record<State, CardState> = {
+  [State.New]: "NEW",
+  [State.Learning]: "LEARNING",
+  [State.Review]: "REVIEW",
+  [State.Relearning]: "RELEARNING",
+};
+
+const RATING_MAP: Record<Rating, FSRSRating> = {
+  1: FSRSRating.Again,
+  2: FSRSRating.Hard,
+  3: FSRSRating.Good,
+  4: FSRSRating.Easy,
+};
+
+function toTSCard(card: FSRSCard): TSCard {
+  const base = createEmptyCard();
+  return {
+    ...base,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    due: new Date(card.dueDate),
+    last_review: card.lastReview ? new Date(card.lastReview) : undefined,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: STATE_MAP[card.state],
+  };
+}
+
+function fromRecordLogItem(item: RecordLogItem, _rating: Rating): FSRSCard {
+  const { card, log } = item;
+  return {
+    stability: card.stability,
+    difficulty: card.difficulty,
+    dueDate: card.due.toISOString(),
+    lastReview: card.last_review?.toISOString() ?? null,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: STATE_REVERSE[card.state],
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Apply a rating to a card and return the updated card state.
+ */
+export function scheduleCard(
+  card: FSRSCard,
+  rating: Rating,
+  now: Date,
+): { card: FSRSCard; log: ReviewLog } {
+  const tsCard = toTSCard(card);
+  const fsrsRating = RATING_MAP[rating];
+  const recordLog = scheduler.repeat(tsCard, now);
+  const item = recordLog[fsrsRating as keyof typeof recordLog] as RecordLogItem;
+
+  const updatedCard = fromRecordLogItem(item, rating);
+  const reviewLog: ReviewLog = {
+    rating,
+    elapsedDays: item.log.elapsed_days,
+    scheduledDays: item.log.scheduled_days,
+    reviewAt: now.toISOString(),
+  };
+
+  return { card: updatedCard, log: reviewLog };
+}
+
+/**
+ * Return cards whose dueDate is on or before `now`.
+ */
+export function getDueCards<T extends FSRSCard>(cards: T[], now: Date): T[] {
+  return cards.filter((c) => new Date(c.dueDate) <= now);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./rating";
+export * from "./fsrs";


### PR DESCRIPTION
## Summary
- Installs `ts-fsrs` v5 in `packages/core`
- `FSRSCard` interface maps our DB schema (stability, difficulty, dueDate, lastReview, reps, lapses, state) to ts-fsrs internal `Card`
- `scheduleCard(card, rating, now)` applies a rating and returns the updated card + a `ReviewLog`
- `getDueCards(cards, now)` filters cards whose `dueDate <= now`, preserves subtypes via generics
- FSRS scheduler uses `request_retention: 0.9`
- All types re-exported from `packages/core` index

## Test plan
- [x] All 4 rating paths (Again/Hard/Good/Easy) for a NEW card
- [x] All 4 rating paths for a REVIEW card
- [x] Again on REVIEW card → lapses increments, state → RELEARNING
- [x] Easy on NEW card → graduates directly to REVIEW
- [x] Easy schedules further out than Good (REVIEW card)
- [x] `getDueCards` returns past + exactly-now cards, excludes future
- [x] `getDueCards` preserves extra fields on extended subtypes
- [x] ReviewLog fields (rating, reviewAt, scheduledDays) are correct
- [x] 19 total tests passing (`pnpm test` in packages/core)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)