### PR TITLE
[03-02] Integrate rs-fsrs into Rust core crate

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -65,6 +80,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "code-recall"
@@ -113,8 +142,10 @@ name = "core-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "dirs",
  "reqwest",
+ "rs-fsrs",
  "rusqlite",
  "serde",
  "serde_json",
@@ -446,6 +477,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +909,17 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rs-fsrs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a7e7d53c16e720833aa109509f46d4d6cc0c4c820f95b865df72c6118e9124"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1440,6 +1515,41 @@ checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -17,6 +17,8 @@ serde_json = "1"
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+rs-fsrs = { version = "1.2.1", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 
 [profile.release]
 opt-level = 3

--- a/apps/cli/core-rs/Cargo.toml
+++ b/apps/cli/core-rs/Cargo.toml
@@ -15,6 +15,8 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
+rs-fsrs = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = "=3.14.0"

--- a/apps/cli/core-rs/src/fsrs.rs
+++ b/apps/cli/core-rs/src/fsrs.rs
@@ -1,2 +1,306 @@
-// FSRS scheduling logic will be implemented in issue [03-02]
-// Integrate rs-fsrs into Rust core crate
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use rs_fsrs::{Card, Parameters, Rating as FsrsRating, State, FSRS};
+use rusqlite::Connection;
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FsrsCard {
+    pub id: String,
+    pub stability: f64,
+    pub difficulty: f64,
+    pub due_date: String,           // ISO 8601
+    pub last_review: Option<String>,
+    pub reps: i64,
+    pub lapses: i64,
+    pub state: String,              // "NEW" | "LEARNING" | "REVIEW" | "RELEARNING"
+}
+
+#[derive(Debug, Clone)]
+pub struct ReviewOutcome {
+    pub updated_card: FsrsCard,
+    pub elapsed_days: i64,
+    pub scheduled_days: i64,
+    pub review_at: String, // ISO 8601
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+fn state_to_fsrs(state: &str) -> State {
+    match state {
+        "LEARNING" => State::Learning,
+        "REVIEW" => State::Review,
+        "RELEARNING" => State::Relearning,
+        _ => State::New,
+    }
+}
+
+fn fsrs_to_state(state: State) -> &'static str {
+    match state {
+        State::New => "NEW",
+        State::Learning => "LEARNING",
+        State::Review => "REVIEW",
+        State::Relearning => "RELEARNING",
+    }
+}
+
+fn rating_from_u8(rating: u8) -> Result<FsrsRating> {
+    match rating {
+        1 => Ok(FsrsRating::Again),
+        2 => Ok(FsrsRating::Hard),
+        3 => Ok(FsrsRating::Good),
+        4 => Ok(FsrsRating::Easy),
+        other => anyhow::bail!("invalid rating {other}: must be 1–4"),
+    }
+}
+
+fn to_rs_card(card: &FsrsCard) -> Result<Card> {
+    let due = card
+        .due_date
+        .parse::<DateTime<Utc>>()
+        .with_context(|| format!("invalid due_date: {}", card.due_date))?;
+
+    let last_review = card
+        .last_review
+        .as_deref()
+        .map(|s| {
+            s.parse::<DateTime<Utc>>()
+                .with_context(|| format!("invalid last_review: {s}"))
+        })
+        .transpose()?
+        .unwrap_or(due);
+
+    Ok(Card {
+        due,
+        stability: card.stability,
+        difficulty: card.difficulty,
+        reps: card.reps as i32,
+        lapses: card.lapses as i32,
+        state: state_to_fsrs(&card.state),
+        last_review,
+        elapsed_days: 0,
+        scheduled_days: 0,
+    })
+}
+
+fn from_rs_card(id: &str, card: &Card) -> FsrsCard {
+    FsrsCard {
+        id: id.to_string(),
+        stability: card.stability,
+        difficulty: card.difficulty,
+        due_date: card.due.to_rfc3339(),
+        last_review: Some(card.last_review.to_rfc3339()),
+        reps: card.reps as i64,
+        lapses: card.lapses as i64,
+        state: fsrs_to_state(card.state).to_string(),
+    }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Apply a rating (1=Again, 2=Hard, 3=Good, 4=Easy) and return the updated
+/// card state. Uses `desired_retention = 0.9` via `Parameters::default()`.
+pub fn schedule_card(
+    card: &FsrsCard,
+    rating: u8,
+    now: DateTime<Utc>,
+) -> Result<ReviewOutcome> {
+    let fsrs_rating = rating_from_u8(rating)?;
+    let rs_card = to_rs_card(card)?;
+
+    let fsrs = FSRS::new(Parameters::default()); // request_retention = 0.9
+    let record_log = fsrs.repeat(rs_card, now);
+
+    let info = record_log
+        .get(&fsrs_rating)
+        .with_context(|| format!("no scheduling info for rating {rating}"))?;
+
+    Ok(ReviewOutcome {
+        updated_card: from_rs_card(&card.id, &info.card),
+        elapsed_days: info.review_log.elapsed_days,
+        scheduled_days: info.review_log.scheduled_days,
+        review_at: now.to_rfc3339(),
+    })
+}
+
+/// Return all cards whose `due_date <= now` from the SQLite database.
+pub fn get_due_cards(conn: &Connection) -> Result<Vec<FsrsCard>> {
+    let now = Utc::now().to_rfc3339();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, stability, difficulty, due_date, last_review, reps, lapses, state
+             FROM cards
+             WHERE due_date <= ?1",
+        )
+        .context("failed to prepare get_due_cards query")?;
+
+    let cards = stmt
+        .query_map([&now], |row| {
+            Ok(FsrsCard {
+                id: row.get(0)?,
+                stability: row.get(1)?,
+                difficulty: row.get(2)?,
+                due_date: row.get(3)?,
+                last_review: row.get(4)?,
+                reps: row.get(5)?,
+                lapses: row.get(6)?,
+                state: row.get(7)?,
+            })
+        })
+        .context("failed to query due cards")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to collect due cards")?;
+
+    Ok(cards)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::run_migrations_for_test;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap()
+    }
+
+    fn new_card(id: &str) -> FsrsCard {
+        FsrsCard {
+            id: id.to_string(),
+            stability: 0.0,
+            difficulty: 0.0,
+            due_date: now().to_rfc3339(),
+            last_review: None,
+            reps: 0,
+            lapses: 0,
+            state: "NEW".to_string(),
+        }
+    }
+
+    fn review_card(id: &str) -> FsrsCard {
+        FsrsCard {
+            id: id.to_string(),
+            stability: 10.0,
+            difficulty: 5.0,
+            due_date: now().to_rfc3339(),
+            last_review: Some(
+                Utc.with_ymd_and_hms(2023, 12, 22, 12, 0, 0)
+                    .unwrap()
+                    .to_rfc3339(),
+            ),
+            reps: 3,
+            lapses: 0,
+            state: "REVIEW".to_string(),
+        }
+    }
+
+    // ── NEW card ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn schedule_new_card_again_not_review() {
+        let outcome = schedule_card(&new_card("1"), 1, now()).unwrap();
+        assert_ne!(outcome.updated_card.state, "REVIEW");
+        let due = outcome.updated_card.due_date.parse::<DateTime<Utc>>().unwrap();
+        assert!(due > now());
+    }
+
+    #[test]
+    fn schedule_new_card_good_future_due() {
+        let outcome = schedule_card(&new_card("1"), 3, now()).unwrap();
+        let due = outcome.updated_card.due_date.parse::<DateTime<Utc>>().unwrap();
+        assert!(due > now(), "dueDate should be in the future after Good");
+    }
+
+    #[test]
+    fn schedule_new_card_easy_graduates_to_review() {
+        let outcome = schedule_card(&new_card("1"), 4, now()).unwrap();
+        assert_eq!(outcome.updated_card.state, "REVIEW");
+        assert!(outcome.updated_card.reps > 0);
+    }
+
+    #[test]
+    fn schedule_new_card_good_increments_reps() {
+        let outcome = schedule_card(&new_card("1"), 3, now()).unwrap();
+        assert!(outcome.updated_card.reps > 0);
+    }
+
+    // ── REVIEW card ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn schedule_review_card_again_increments_lapses() {
+        let outcome = schedule_card(&review_card("1"), 1, now()).unwrap();
+        assert!(outcome.updated_card.lapses > 0);
+        assert_eq!(outcome.updated_card.state, "RELEARNING");
+    }
+
+    #[test]
+    fn schedule_review_card_good_stays_in_review() {
+        let outcome = schedule_card(&review_card("1"), 3, now()).unwrap();
+        assert_eq!(outcome.updated_card.state, "REVIEW");
+        let due = outcome.updated_card.due_date.parse::<DateTime<Utc>>().unwrap();
+        assert!(due > now());
+    }
+
+    #[test]
+    fn schedule_review_card_easy_further_than_good() {
+        let good = schedule_card(&review_card("1"), 3, now()).unwrap();
+        let easy = schedule_card(&review_card("1"), 4, now()).unwrap();
+        let good_due = good.updated_card.due_date.parse::<DateTime<Utc>>().unwrap();
+        let easy_due = easy.updated_card.due_date.parse::<DateTime<Utc>>().unwrap();
+        assert!(easy_due > good_due, "Easy should schedule further than Good");
+    }
+
+    // ── get_due_cards ─────────────────────────────────────────────────────────
+
+    fn in_memory_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        run_migrations_for_test(&conn).unwrap();
+        conn
+    }
+
+    fn insert_card(conn: &Connection, id: &str, due: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, email, name) VALUES ('u1', 'a@b.com', 'Test')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO decks (id, user_id, name) VALUES ('d1', 'u1', 'Deck')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO cards (id, deck_id, card_type, title, content, due_date)
+             VALUES (?1, 'd1', 'CODING', 'title', 'content', ?2)",
+            rusqlite::params![id, due],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn get_due_cards_returns_past_cards() {
+        let conn = in_memory_conn();
+        insert_card(&conn, "c1", "2023-01-01T00:00:00+00:00");
+        let due = get_due_cards(&conn).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].id, "c1");
+    }
+
+    #[test]
+    fn get_due_cards_excludes_future() {
+        let conn = in_memory_conn();
+        insert_card(&conn, "c2", "2099-01-01T00:00:00+00:00");
+        let due = get_due_cards(&conn).unwrap();
+        assert!(due.is_empty());
+    }
+
+    #[test]
+    fn invalid_rating_returns_error() {
+        let result = schedule_card(&new_card("1"), 5, now());
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `rs-fsrs v1.2.1` + `chrono v0.4` to workspace and `core-rs` dependencies
- `FsrsCard` struct maps our SQLite schema fields to `rs_fsrs::Card` and back
- `schedule_card(card, rating, now)` applies a 1–4 rating and returns `ReviewOutcome` (updated card + elapsed/scheduled days); returns `Err` for invalid ratings
- `get_due_cards(conn)` queries SQLite for cards with `due_date <= now`
- State mapping: `NEW/LEARNING/REVIEW/RELEARNING` ↔ `rs_fsrs::State`
- `desired_retention = 0.9` via `Parameters::default()`

## Test plan
- [x] NEW card rated Again → state ≠ REVIEW, due in future
- [x] NEW card rated Good → due in future, reps increments
- [x] NEW card rated Easy → graduates to REVIEW
- [x] REVIEW card rated Again → lapses increments, state → RELEARNING
- [x] REVIEW card rated Good → stays REVIEW, due in future
- [x] REVIEW card rated Easy → scheduled further out than Good
- [x] `get_due_cards` returns past cards, excludes future
- [x] Invalid rating (5) returns `Err`
- [x] All 14 `cargo test -p core-rs` tests pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)