### PR TITLE
[03-03] Define rating-to-FSRS mapping for coding challenges

### DIFF
--- a/apps/cli/core-rs/src/fsrs.rs
+++ b/apps/cli/core-rs/src/fsrs.rs
@@ -1,2 +1,57 @@
-// FSRS scheduling logic will be implemented in issue [03-02]
-// Integrate rs-fsrs into Rust core crate
+/// Convert a test-result pass percentage to an FSRS rating.
+///
+///  0%        → 1 (Again)  — nothing passed
+///  1 – 49%   → 2 (Hard)   — partial, less than half
+///  50 – 99%  → 3 (Good)   — majority passed but not perfect
+///  100%      → 4 (Easy)   — all tests passed on first attempt
+pub fn test_result_to_rating(pass_percent: i32) -> u8 {
+    if pass_percent <= 0 {
+        1 // Again
+    } else if pass_percent < 50 {
+        2 // Hard
+    } else if pass_percent < 100 {
+        3 // Good
+    } else {
+        4 // Easy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_percent_is_again() {
+        assert_eq!(test_result_to_rating(0), 1);
+    }
+
+    #[test]
+    fn negative_percent_is_again() {
+        assert_eq!(test_result_to_rating(-1), 1);
+    }
+
+    #[test]
+    fn one_percent_is_hard() {
+        assert_eq!(test_result_to_rating(1), 2);
+    }
+
+    #[test]
+    fn forty_nine_percent_is_hard() {
+        assert_eq!(test_result_to_rating(49), 2);
+    }
+
+    #[test]
+    fn fifty_percent_is_good() {
+        assert_eq!(test_result_to_rating(50), 3);
+    }
+
+    #[test]
+    fn ninety_nine_percent_is_good() {
+        assert_eq!(test_result_to_rating(99), 3);
+    }
+
+    #[test]
+    fn hundred_percent_is_easy() {
+        assert_eq!(test_result_to_rating(100), 4);
+    }
+}

--- a/packages/core/src/rating.test.ts
+++ b/packages/core/src/rating.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Rating, isValidRating } from "./rating";
+import { Rating, isValidRating, testResultToRating } from "./rating";
 
 describe("isValidRating", () => {
   it("accepts all four FSRS ratings", () => {
@@ -16,5 +16,35 @@ describe("isValidRating", () => {
 
   it("rejects non-integer values", () => {
     expect(isValidRating(2.5)).toBe(false);
+  });
+});
+
+describe("testResultToRating", () => {
+  it("0% → Again", () => {
+    expect(testResultToRating(0)).toBe(Rating.Again);
+  });
+
+  it("negative % → Again (treated as 0)", () => {
+    expect(testResultToRating(-1)).toBe(Rating.Again);
+  });
+
+  it("1% → Hard", () => {
+    expect(testResultToRating(1)).toBe(Rating.Hard);
+  });
+
+  it("49% → Hard", () => {
+    expect(testResultToRating(49)).toBe(Rating.Hard);
+  });
+
+  it("50% → Good", () => {
+    expect(testResultToRating(50)).toBe(Rating.Good);
+  });
+
+  it("99% → Good", () => {
+    expect(testResultToRating(99)).toBe(Rating.Good);
+  });
+
+  it("100% → Easy", () => {
+    expect(testResultToRating(100)).toBe(Rating.Easy);
   });
 });

--- a/packages/core/src/rating.ts
+++ b/packages/core/src/rating.ts
@@ -11,3 +11,20 @@ export type Rating = (typeof Rating)[keyof typeof Rating];
 export function isValidRating(value: number): value is Rating {
   return value >= 1 && value <= 4 && Number.isInteger(value);
 }
+
+/**
+ * Convert a test-result pass percentage to an FSRS rating.
+ *
+ *  0%        → Again (1)  — nothing passed
+ *  1 – 49%   → Hard  (2)  — partial, less than half
+ *  50 – 99%  → Good  (3)  — majority passed but not perfect
+ *  100%      → Easy  (4)  — all tests passed on first attempt
+ *
+ * @param passPercent Integer 0–100 representing the percentage of test cases passed.
+ */
+export function testResultToRating(passPercent: number): Rating {
+  if (passPercent <= 0) return Rating.Again;
+  if (passPercent < 50) return Rating.Hard;
+  if (passPercent < 100) return Rating.Good;
+  return Rating.Easy;
+}


### PR DESCRIPTION
## Summary
- Adds `testResultToRating(passPercent: number): Rating` to `packages/core`
- Adds `test_result_to_rating(pass_percent: i32) -> u8` to `core-rs` (mirrors TS exactly)
- Mapping: 0% → Again, 1–49% → Hard, 50–99% → Good, 100% → Easy
- Both implementations handle negative input as Again

## Test plan
- [x] 0% → Again
- [x] Negative % → Again
- [x] 1% → Hard (lower boundary)
- [x] 49% → Hard (upper boundary)
- [x] 50% → Good (lower boundary)
- [x] 99% → Good (upper boundary)
- [x] 100% → Easy
- [x] All boundaries tested in both TypeScript (10 total tests) and Rust (7 tests)

## Notes
UI behavior (rating prompt after submission, manual override) will be implemented in E07 CLI tickets.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)