### PR TITLE
[E04] Scaffold Hono.js AI service + implement all generation & evaluation endpoints

### DIFF
--- a/apps/ai-service/package.json
+++ b/apps/ai-service/package.json
@@ -4,16 +4,27 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "echo \"ai-service: no dev server yet\"",
-    "build": "echo \"ai-service: no build yet\"",
-    "test": "echo \"ai-service: no tests yet\"",
-    "lint": "echo \"ai-service: no lint yet\""
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "echo \"ai-service: integration tests require ANTHROPIC_API_KEY\"",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "@repo/db": "workspace:*"
+    "@anthropic-ai/sdk": "^0.80.0",
+    "@hono/node-server": "^1.19.11",
+    "@repo/db": "workspace:*",
+    "hono": "^4.12.9",
+    "zod": "^4.3.6"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@10.28.2",
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  }
 }

--- a/apps/ai-service/src/index.ts
+++ b/apps/ai-service/src/index.ts
@@ -1,0 +1,24 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { generateRoutes } from "./routes/generate";
+import { evaluateRoutes } from "./routes/evaluate";
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("ANTHROPIC_API_KEY is required");
+  process.exit(1);
+}
+
+const app = new Hono();
+
+app.get("/health", (c) => c.json({ status: "ok" }));
+app.route("/generate", generateRoutes);
+app.route("/evaluate", evaluateRoutes);
+
+// Consistent error shape for unhandled routes
+app.notFound((c) => c.json({ error: "Not found", code: "NOT_FOUND" }, 404));
+
+const port = parseInt(process.env.PORT ?? "3001", 10);
+
+serve({ fetch: app.fetch, port }, () => {
+  console.log(`AI service listening on port ${port}`);
+});

--- a/apps/ai-service/src/lib/anthropic.ts
+++ b/apps/ai-service/src/lib/anthropic.ts
@@ -1,0 +1,6 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+export const MODEL = "claude-opus-4-6" as const;
+
+// Lazy singleton — key validation happens at startup in index.ts
+export const anthropic = new Anthropic();

--- a/apps/ai-service/src/lib/errors.ts
+++ b/apps/ai-service/src/lib/errors.ts
@@ -1,0 +1,20 @@
+import type { Context } from "hono";
+
+export class AppError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number = 400,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export function handleError(c: Context, error: unknown) {
+  if (error instanceof AppError) {
+    return c.json({ error: error.message, code: error.code }, error.status as 400 | 422 | 500);
+  }
+  console.error("Unexpected error:", error);
+  return c.json({ error: "Internal server error", code: "INTERNAL_ERROR" }, 500);
+}

--- a/apps/ai-service/src/prompts/coding-v1.ts
+++ b/apps/ai-service/src/prompts/coding-v1.ts
@@ -1,0 +1,19 @@
+export interface CodingPromptParams {
+  topic: string;
+  difficulty: "easy" | "medium" | "hard";
+  language: string;
+}
+
+export function buildCodingPrompt({ topic, difficulty, language }: CodingPromptParams): string {
+  return `You are an expert programming instructor creating coding challenges for spaced repetition learning.
+
+Generate a ${difficulty} difficulty coding challenge about "${topic}" in ${language}.
+
+Requirements:
+- The challenge must directly test "${topic}" — keep the scope focused
+- Include at least 5 test cases; at least 2 must be edge cases (empty input, boundary values, null/undefined, duplicates, max values)
+- Test case inputs and expected outputs must exactly match the function signature
+- starter_code must compile and contain only the function signature with an empty/stub body
+- Hints should be progressive: the first barely nudges, later ones reveal more
+- time_complexity and space_complexity reflect the optimal solution`;
+}

--- a/apps/ai-service/src/prompts/multiple-choice-v1.ts
+++ b/apps/ai-service/src/prompts/multiple-choice-v1.ts
@@ -1,0 +1,18 @@
+export interface MCPromptParams {
+  topic: string;
+  difficulty: "easy" | "medium" | "hard";
+}
+
+export function buildMultipleChoicePrompt({ topic, difficulty }: MCPromptParams): string {
+  return `You are an expert creating multiple choice questions for developer knowledge assessment.
+
+Generate a ${difficulty} difficulty multiple choice question about "${topic}".
+
+Requirements:
+- Exactly 4 options (ids: "a", "b", "c", "d")
+- Exactly 1 correct answer
+- Distractors must be plausibly wrong — not obviously incorrect
+- Every option must have a clear explanation of why it is correct or incorrect
+- No duplicate options
+- Tags should be specific sub-topics related to the question`;
+}

--- a/apps/ai-service/src/prompts/open-ended-v1.ts
+++ b/apps/ai-service/src/prompts/open-ended-v1.ts
@@ -1,0 +1,41 @@
+export interface OEGenerateParams {
+  topic: string;
+  difficulty: "easy" | "medium" | "hard";
+}
+
+export function buildOpenEndedGeneratePrompt({ topic, difficulty }: OEGenerateParams): string {
+  return `You are an expert creating open-ended questions for developer knowledge assessment.
+
+Generate a ${difficulty} difficulty open-ended question about "${topic}".
+
+Requirements:
+- The question should require conceptual understanding, not just recall
+- model_answer must be comprehensive yet concise (2–4 sentences)
+- evaluation_criteria should list the key concepts a complete answer must cover
+- Tags should reflect relevant sub-topics`;
+}
+
+export interface OEEvalParams {
+  question: string;
+  userAnswer: string;
+  modelAnswer?: string;
+}
+
+export function buildOpenEndedEvalPrompt({
+  question,
+  userAnswer,
+  modelAnswer,
+}: OEEvalParams): string {
+  const ref = modelAnswer ? `\nReference answer: ${modelAnswer}` : "";
+  return `You are an expert grading developer knowledge answers.
+
+Question: ${question}${ref}
+
+User answer: ${userAnswer}
+
+Evaluate and return:
+- score: 1–4 (1=Again — doesn't understand, 2=Hard — partial, 3=Good — solid, 4=Easy — mastery)
+- feedback: constructive, specific, under 100 words
+- missing_concepts: short phrases for concepts absent or underdeveloped in the answer
+- suggested_rating: same value as score (direct FSRS rating)`;
+}

--- a/apps/ai-service/src/routes/evaluate.ts
+++ b/apps/ai-service/src/routes/evaluate.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { anthropic, MODEL } from "../lib/anthropic";
+import { AppError, handleError } from "../lib/errors";
+import { buildOpenEndedEvalPrompt } from "../prompts/open-ended-v1";
+
+export const evaluateRoutes = new Hono();
+
+// ─── Output schema ────────────────────────────────────────────────────────────
+
+const OpenEndedEvalSchema = z.object({
+  score: z
+    .number()
+    .int()
+    .describe("1=Again, 2=Hard, 3=Good, 4=Easy — maps directly to FSRS ratings"),
+  feedback: z.string().describe("Constructive, specific feedback under 100 words"),
+  missing_concepts: z
+    .array(z.string())
+    .describe("Short phrases for absent or underdeveloped concepts"),
+  suggested_rating: z.number().int().describe("FSRS rating 1–4, same value as score"),
+});
+
+// ─── POST /evaluate/open-ended ────────────────────────────────────────────────
+
+const OEEvalInputSchema = z.object({
+  question: z.string().min(1),
+  user_answer: z.string().min(1),
+  model_answer: z.string().optional(),
+});
+
+evaluateRoutes.post("/open-ended", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = OEEvalInputSchema.safeParse(body);
+    if (!input.success) {
+      throw new AppError("VALIDATION_ERROR", input.error.message);
+    }
+    const { question, user_answer, model_answer } = input.data;
+
+    const prompt = buildOpenEndedEvalPrompt({
+      question,
+      userAnswer: user_answer,
+      modelAnswer: model_answer,
+    });
+
+    const response = await anthropic.messages.parse({
+      model: MODEL,
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+      output_config: { format: zodOutputFormat(OpenEndedEvalSchema) },
+    });
+
+    if (!response.parsed_output) {
+      throw new AppError("EVALUATION_FAILED", "Failed to parse evaluation response", 500);
+    }
+
+    const result = response.parsed_output;
+
+    // Clamp score to valid FSRS range (1–4) in case Claude drifts
+    const score = Math.max(1, Math.min(4, result.score)) as 1 | 2 | 3 | 4;
+
+    return c.json({
+      score,
+      feedback: result.feedback,
+      missing_concepts: result.missing_concepts,
+      suggested_rating: score,
+    });
+  } catch (error) {
+    return handleError(c, error);
+  }
+});

--- a/apps/ai-service/src/routes/generate.ts
+++ b/apps/ai-service/src/routes/generate.ts
@@ -1,0 +1,257 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { anthropic, MODEL } from "../lib/anthropic";
+import { AppError, handleError } from "../lib/errors";
+import { buildCodingPrompt } from "../prompts/coding-v1";
+import { buildMultipleChoicePrompt } from "../prompts/multiple-choice-v1";
+import { buildOpenEndedGeneratePrompt } from "../prompts/open-ended-v1";
+import { db } from "../lib/db";
+import { cards, decks } from "@repo/db";
+
+export const generateRoutes = new Hono();
+
+// ─── Output schemas ───────────────────────────────────────────────────────────
+
+const TestCaseSchema = z.object({
+  input: z.string().describe("Input to the function as a string"),
+  expected_output: z.string().describe("Expected output as a string"),
+  is_edge_case: z.boolean().describe("True if this is an edge case"),
+  description: z.string().describe("What this test case validates"),
+});
+
+const CodingChallengeSchema = z.object({
+  title: z.string().describe("Short descriptive title"),
+  description: z.string().describe("Full problem statement"),
+  function_signature: z.string().describe("Function signature in the target language"),
+  starter_code: z.string().describe("Compilable stub with empty body"),
+  test_cases: z.array(TestCaseSchema).describe("Minimum 5 test cases, at least 2 edge cases"),
+  hints: z.array(z.string()).describe("Progressive hints, easiest first"),
+  time_complexity: z.string().describe("Optimal time complexity, e.g. O(n log n)"),
+  space_complexity: z.string().describe("Optimal space complexity, e.g. O(1)"),
+});
+
+const OptionSchema = z.object({
+  id: z.string().describe("Single letter: a, b, c, or d"),
+  body: z.string().describe("Option text"),
+  is_correct: z.boolean().describe("True for the correct option"),
+  explanation: z.string().describe("Why this option is right or wrong"),
+});
+
+const MultipleChoiceSchema = z.object({
+  question: z.string().describe("The question text"),
+  options: z.array(OptionSchema).describe("Exactly 4 options, exactly 1 correct"),
+  overall_explanation: z.string().describe("Full explanation of the correct answer"),
+  tags: z.array(z.string()).describe("Relevant sub-topic tags"),
+});
+
+const OpenEndedSchema = z.object({
+  question: z.string().describe("The open-ended question"),
+  model_answer: z.string().describe("A comprehensive model answer (2–4 sentences)"),
+  evaluation_criteria: z.array(z.string()).describe("Key concepts a complete answer must cover"),
+  tags: z.array(z.string()).describe("Relevant sub-topic tags"),
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const DifficultySchema = z.enum(["easy", "medium", "hard"]);
+
+async function callClaude<T>(prompt: string, schema: z.ZodType<T>, retries = 1): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const response = await anthropic.messages.parse({
+      model: MODEL,
+      max_tokens: 16000,
+      messages: [{ role: "user", content: prompt }],
+      output_config: { format: zodOutputFormat(schema) },
+    });
+    if (response.parsed_output !== null) return response.parsed_output as T;
+  }
+  throw new AppError("GENERATION_FAILED", "Failed to generate a valid response after retry", 500);
+}
+
+// ─── POST /generate/coding ────────────────────────────────────────────────────
+
+const CodingInputSchema = z.object({
+  topic: z.string().min(1),
+  difficulty: DifficultySchema,
+  language: z.string().min(1),
+  count: z.number().int().min(1).max(10).optional().default(1),
+});
+
+generateRoutes.post("/coding", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = CodingInputSchema.safeParse(body);
+    if (!input.success) {
+      throw new AppError("VALIDATION_ERROR", input.error.message);
+    }
+    const { topic, difficulty, language, count } = input.data;
+    const prompt = buildCodingPrompt({ topic, difficulty, language });
+
+    const challenges = await Promise.all(
+      Array.from({ length: count }, () => callClaude(prompt, CodingChallengeSchema)),
+    );
+
+    return c.json({ challenges });
+  } catch (error) {
+    return handleError(c, error);
+  }
+});
+
+// ─── POST /generate/multiple-choice ──────────────────────────────────────────
+
+const MCInputSchema = z.object({
+  topic: z.string().min(1),
+  difficulty: DifficultySchema,
+  count: z.number().int().min(1).max(20).optional().default(1),
+});
+
+generateRoutes.post("/multiple-choice", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = MCInputSchema.safeParse(body);
+    if (!input.success) {
+      throw new AppError("VALIDATION_ERROR", input.error.message);
+    }
+    const { topic, difficulty, count } = input.data;
+    const prompt = buildMultipleChoicePrompt({ topic, difficulty });
+
+    const questions = await Promise.all(
+      Array.from({ length: count }, () => callClaude(prompt, MultipleChoiceSchema)),
+    );
+
+    return c.json({ questions });
+  } catch (error) {
+    return handleError(c, error);
+  }
+});
+
+// ─── POST /generate/open-ended ────────────────────────────────────────────────
+
+const OEInputSchema = z.object({
+  topic: z.string().min(1),
+  difficulty: DifficultySchema,
+  count: z.number().int().min(1).max(20).optional().default(1),
+});
+
+generateRoutes.post("/open-ended", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = OEInputSchema.safeParse(body);
+    if (!input.success) {
+      throw new AppError("VALIDATION_ERROR", input.error.message);
+    }
+    const { topic, difficulty, count } = input.data;
+    const prompt = buildOpenEndedGeneratePrompt({ topic, difficulty });
+
+    const questions = await Promise.all(
+      Array.from({ length: count }, () => callClaude(prompt, OpenEndedSchema)),
+    );
+
+    return c.json({ questions });
+  } catch (error) {
+    return handleError(c, error);
+  }
+});
+
+// ─── POST /generate/deck ─────────────────────────────────────────────────────
+
+const DeckInputSchema = z.object({
+  topic: z.string().min(1),
+  card_count: z.number().int().min(1).max(50),
+  difficulty: DifficultySchema,
+  language: z.string().min(1).optional().default("TypeScript"),
+  user_id: z.string().min(1),
+  deck_name: z.string().min(1).optional(),
+});
+
+generateRoutes.post("/deck", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = DeckInputSchema.safeParse(body);
+    if (!input.success) {
+      throw new AppError("VALIDATION_ERROR", input.error.message);
+    }
+    const { topic, card_count, difficulty, language, user_id, deck_name } = input.data;
+
+    // ~40% coding, ~30% MC, ~30% open-ended
+    const codingCount = Math.round(card_count * 0.4);
+    const mcCount = Math.round(card_count * 0.3);
+    const oeCount = card_count - codingCount - mcCount;
+
+    const [codingResults, mcResults, oeResults] = await Promise.all([
+      Promise.all(
+        Array.from({ length: codingCount }, () =>
+          callClaude(buildCodingPrompt({ topic, difficulty, language }), CodingChallengeSchema),
+        ),
+      ),
+      Promise.all(
+        Array.from({ length: mcCount }, () =>
+          callClaude(buildMultipleChoicePrompt({ topic, difficulty }), MultipleChoiceSchema),
+        ),
+      ),
+      Promise.all(
+        Array.from({ length: oeCount }, () =>
+          callClaude(buildOpenEndedGeneratePrompt({ topic, difficulty }), OpenEndedSchema),
+        ),
+      ),
+    ]);
+
+    const deckId = crypto.randomUUID();
+    const deckTitle = deck_name ?? `${topic} — ${difficulty}`;
+    const now = new Date().toISOString();
+
+    const cardRows = [
+      ...codingResults.map((ch) => ({
+        id: crypto.randomUUID(),
+        deckId,
+        cardType: "CODING" as const,
+        title: ch.title,
+        content: JSON.stringify(ch),
+        createdAt: now,
+        updatedAt: now,
+        dueDate: now,
+      })),
+      ...mcResults.map((q) => ({
+        id: crypto.randomUUID(),
+        deckId,
+        cardType: "MULTIPLE_CHOICE" as const,
+        title: q.question.slice(0, 120),
+        content: JSON.stringify(q),
+        createdAt: now,
+        updatedAt: now,
+        dueDate: now,
+      })),
+      ...oeResults.map((q) => ({
+        id: crypto.randomUUID(),
+        deckId,
+        cardType: "OPEN_ENDED" as const,
+        title: q.question.slice(0, 120),
+        content: JSON.stringify(q),
+        createdAt: now,
+        updatedAt: now,
+        dueDate: now,
+      })),
+    ];
+
+    await db.transaction(async (tx) => {
+      await tx.insert(decks).values({
+        id: deckId,
+        userId: user_id,
+        name: deckTitle,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await tx.insert(cards).values(cardRows);
+    });
+
+    return c.json({
+      deck_id: deckId,
+      deck_name: deckTitle,
+      card_count: cardRows.length,
+      cards: cardRows.map(({ id, cardType, title }) => ({ id, cardType, title })),
+    });
+  } catch (error) {
+    return handleError(c, error);
+  }
+});

--- a/apps/ai-service/tsconfig.json
+++ b/apps/ai-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Implements the full E04 AI Service epic in one PR:

- **Hono.js** app on port 3001, `@hono/node-server` for Node.js
- **`claude-opus-4-6`** via `@anthropic-ai/sdk` with `zodOutputFormat` structured output (`messages.parse()`)
- Zod input validation on every route; consistent `{ error, code }` error shape on failure
- `GET /health` + `404` handler

### Endpoints

| Route | Issue | Description |
|---|---|---|
| `POST /generate/coding` | #12 | Coding challenge — title, description, function signature, starter code, ≥5 test cases (≥2 edge), hints, complexity |
| `POST /generate/multiple-choice` | #13 | MC question — exactly 4 options, exactly 1 correct, per-option explanations |
| `POST /generate/open-ended` | #11 | OE question + model answer + evaluation criteria |
| `POST /evaluate/open-ended` | #14 | Grades free-text answer → score 1–4, feedback, missing concepts, suggested FSRS rating |
| `POST /generate/deck` | #15 | Generates ~40% coding / ~30% MC / ~30% OE; writes to DB atomically in a single transaction |

### Architecture
- `src/prompts/*-v1.ts` — versioned prompt templates (coding-v1, multiple-choice-v1, open-ended-v1)
- `src/lib/anthropic.ts` — singleton client + model constant
- `src/lib/errors.ts` — `AppError` class + `handleError` helper
- `callClaude()` retries once on parse failure (satisfies #12 acceptance criteria)
- Score in `/evaluate/open-ended` clamped to 1–4 as a safety guard

## Test plan
- [ ] `ANTHROPIC_API_KEY=xxx pnpm dev` → service starts on port 3001
- [ ] `curl localhost:3001/health` → `{"status":"ok"}`
- [ ] `POST /generate/coding` with `{topic, difficulty, language}` → returns valid coding challenge with ≥5 test cases
- [ ] `POST /generate/multiple-choice` → exactly 4 options, exactly 1 `is_correct: true`
- [ ] `POST /evaluate/open-ended` → score in 1–4, feedback present
- [ ] `POST /generate/deck` → deck created in DB, cards written atomically
- [ ] Invalid body → `400 { error, code: "VALIDATION_ERROR" }`
- [ ] Missing `ANTHROPIC_API_KEY` → process exits with error message

Closes #11, #12, #13, #14, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)